### PR TITLE
flash_stm32h7x.c: fix fault when cache disabled

### DIFF
--- a/drivers/flash/flash_stm32h7x.c
+++ b/drivers/flash/flash_stm32h7x.c
@@ -449,6 +449,11 @@ static void flash_stm32h7_flush_caches(const struct device *dev,
 				       off_t offset, size_t len)
 {
 	ARG_UNUSED(dev);
+
+	if (!(SCB->CCR & SCB_CCR_DC_Msk)) {
+		return; /* Cache not enabled */
+	}
+
 	SCB_InvalidateDCache_by_Addr((uint32_t *)(CONFIG_FLASH_BASE_ADDRESS
 						  + offset), len);
 }


### PR DESCRIPTION
In the STM32H7 internal flash driver the data cache is currently invalidated even if it is disabled. When cache is not enabled this can lead to a bus fault. This PR adds a simple check to avoid that issue.