### PR TITLE
settings: stm32h7 flash memory support

### DIFF
--- a/include/fs/fcb.h
+++ b/include/fs/fcb.h
@@ -117,6 +117,9 @@ struct fcb {
 	uint16_t f_active_id;
 	/**< Flash location where the newest data is, internal state */
 
+	uint16_t f_hdr_len;
+	/**< Size of header in bytes, aligned to f_align, internal state */
+
 	uint8_t f_align;
 	/**< writes to flash have to aligned to this, internal state */
 

--- a/subsys/fs/fcb/Kconfig
+++ b/subsys/fs/fcb/Kconfig
@@ -12,3 +12,16 @@ config FCB
 	depends on FLASH_MAP
 	help
 	  Enable support of Flash Circular Buffer.
+
+if FCB
+
+config FCB_MAX_ALIGN
+	int "Maximum supported write-block alignment"
+	default 8
+	help
+	  Specify the maximum write-block alignment, in bytes, that is
+	  supported by the Flash Circular Buffer implementation. Accessing
+	  through the Flash Circular Buffer subsystem a flash memory with larger
+	  alignment requirement will not be possible.
+
+endif

--- a/subsys/fs/fcb/fcb_append.c
+++ b/subsys/fs/fcb/fcb_append.c
@@ -51,7 +51,7 @@ fcb_append_to_scratch(struct fcb *fcb)
 		return rc;
 	}
 	fcb->f_active.fe_sector = sector;
-	fcb->f_active.fe_elem_off = sizeof(struct fcb_disk_area);
+	fcb->f_active.fe_elem_off = fcb->f_hdr_len;
 	fcb->f_active_id++;
 	return 0;
 }
@@ -63,7 +63,7 @@ fcb_append(struct fcb *fcb, uint16_t len, struct fcb_entry *append_loc)
 	struct fcb_entry *active;
 	int cnt;
 	int rc;
-	uint8_t tmp_str[8];
+	uint8_t tmp_str[CONFIG_FCB_MAX_ALIGN];
 
 	cnt = fcb_put_len(fcb, tmp_str, len);
 	if (cnt < 0) {
@@ -82,7 +82,7 @@ fcb_append(struct fcb *fcb, uint16_t len, struct fcb_entry *append_loc)
 	if (active->fe_elem_off + len + cnt > active->fe_sector->fs_size) {
 		sector = fcb_new_sector(fcb, fcb->f_scratch_cnt);
 		if (!sector || (sector->fs_size <
-			sizeof(struct fcb_disk_area) + len + cnt)) {
+			fcb->f_hdr_len + len + cnt)) {
 			rc = -ENOSPC;
 			goto err;
 		}
@@ -91,7 +91,7 @@ fcb_append(struct fcb *fcb, uint16_t len, struct fcb_entry *append_loc)
 			goto err;
 		}
 		fcb->f_active.fe_sector = sector;
-		fcb->f_active.fe_elem_off = sizeof(struct fcb_disk_area);
+		fcb->f_active.fe_elem_off = fcb->f_hdr_len;
 		fcb->f_active_id++;
 	}
 

--- a/subsys/fs/fcb/fcb_getnext.c
+++ b/subsys/fs/fcb/fcb_getnext.c
@@ -55,7 +55,7 @@ fcb_getnext_nolock(struct fcb *fcb, struct fcb_entry *loc)
 		/*
 		 * If offset is zero, we serve the first entry from the sector.
 		 */
-		loc->fe_elem_off = sizeof(struct fcb_disk_area);
+		loc->fe_elem_off = fcb->f_hdr_len;
 		rc = fcb_elem_info(fcb, loc);
 		switch (rc) {
 		case 0:
@@ -89,7 +89,7 @@ next_sector:
 				return -ENOTSUP;
 			}
 			loc->fe_sector = fcb_getnext_sector(fcb, loc->fe_sector);
-			loc->fe_elem_off = sizeof(struct fcb_disk_area);
+			loc->fe_elem_off = fcb->f_hdr_len;
 			rc = fcb_elem_info(fcb, loc);
 			switch (rc) {
 			case 0:

--- a/subsys/fs/fcb/fcb_rotate.c
+++ b/subsys/fs/fcb/fcb_rotate.c
@@ -35,7 +35,7 @@ fcb_rotate(struct fcb *fcb)
 			goto out;
 		}
 		fcb->f_active.fe_sector = sector;
-		fcb->f_active.fe_elem_off = sizeof(struct fcb_disk_area);
+		fcb->f_active.fe_elem_off = fcb->f_hdr_len;
 		fcb->f_active_id++;
 	}
 	fcb->f_oldest = fcb_getnext_sector(fcb, fcb->f_oldest);

--- a/subsys/settings/Kconfig
+++ b/subsys/settings/Kconfig
@@ -28,6 +28,15 @@ config SETTINGS_DYNAMIC_HANDLERS
 	help
 	  Enables the use of dynamic settings handlers
 
+config SETTINGS_IO_BUF_SIZE
+	int "I/O buffer size"
+	depends on SETTINGS
+	default 16
+	help
+	  Define the size, in bytes, of the buffer used by settings subsystem to
+	  read and write to the storage medium. This value must be >= 2 bytes
+	  and a multiple of the storage medium read and write block size.
+
 # Hidden option to enable encoding length into settings entry
 config SETTINGS_ENCODE_LEN
 	depends on SETTINGS

--- a/subsys/settings/include/settings/settings_fcb.h
+++ b/subsys/settings/include/settings/settings_fcb.h
@@ -20,7 +20,7 @@ struct settings_fcb {
 	struct fcb cf_fcb;
 };
 
-extern int settings_fcb_src(struct settings_fcb *cf, int f_area_id);
+extern int settings_fcb_src(struct settings_fcb *cf);
 extern int settings_fcb_dst(struct settings_fcb *cf);
 void settings_mount_fcb_backend(struct settings_fcb *cf);
 int settings_fcb_get_flash_area(void);

--- a/subsys/settings/include/settings/settings_fcb.h
+++ b/subsys/settings/include/settings/settings_fcb.h
@@ -20,9 +20,10 @@ struct settings_fcb {
 	struct fcb cf_fcb;
 };
 
-extern int settings_fcb_src(struct settings_fcb *cf);
+extern int settings_fcb_src(struct settings_fcb *cf, int f_area_id);
 extern int settings_fcb_dst(struct settings_fcb *cf);
 void settings_mount_fcb_backend(struct settings_fcb *cf);
+int settings_fcb_get_flash_area(void);
 
 #ifdef __cplusplus
 }

--- a/subsys/settings/src/settings_fcb.c
+++ b/subsys/settings/src/settings_fcb.c
@@ -32,9 +32,12 @@ static const struct settings_store_itf settings_fcb_itf = {
 	.csi_save = settings_fcb_save,
 };
 
-int settings_fcb_src(struct settings_fcb *cf, int f_area_id)
+int settings_fcb_src(struct settings_fcb *cf)
 {
 	int rc;
+	int f_area_id;
+
+	f_area_id = settings_fcb_get_flash_area();
 
 	cf->cf_fcb.f_version = SETTINGS_FCB_VERS;
 	cf->cf_fcb.f_scratch_cnt = 1;
@@ -401,7 +404,7 @@ int settings_backend_init(void)
 
 	config_init_settings_fcb.cf_fcb.f_sector_cnt = cnt;
 
-	rc = settings_fcb_src(&config_init_settings_fcb, f_area_id);
+	rc = settings_fcb_src(&config_init_settings_fcb);
 
 	if (rc != 0) {
 		rc = flash_area_open(f_area_id, &fap);
@@ -414,8 +417,7 @@ int settings_backend_init(void)
 		if (rc != 0) {
 			k_panic();
 		} else {
-			rc = settings_fcb_src(&config_init_settings_fcb,
-					      f_area_id);
+			rc = settings_fcb_src(&config_init_settings_fcb);
 		}
 	}
 

--- a/subsys/settings/src/settings_line.c
+++ b/subsys/settings/src/settings_line.c
@@ -28,9 +28,11 @@ int settings_line_write(const char *name, const char *value, size_t val_len,
 {
 	size_t w_size, rem, add;
 
+	/* write buff, must be aligned either to minimal */
+	/* base64 encoding size and write-block-size */
+	char w_buf[CONFIG_SETTINGS_IO_BUF_SIZE];
+
 	bool done;
-	char w_buf[16]; /* write buff, must be aligned either to minimal */
-			/* base64 encoding size and write-block-size */
 	int rc;
 	uint8_t wbs = settings_io_cb.rwbs;
 #ifdef CONFIG_SETTINGS_ENCODE_LEN
@@ -181,8 +183,10 @@ static int settings_line_raw_read_until(off_t seek, char *out, size_t len_req,
 				 size_t *len_read, char const *until_char,
 				 void *cb_arg)
 {
+	/* buffer for fit read-block-size requirements */
+	char temp_buf[CONFIG_SETTINGS_IO_BUF_SIZE];
+
 	size_t rem_size, len;
-	char temp_buf[16]; /* buffer for fit read-block-size requirements */
 	size_t exp_size, read_size;
 	uint8_t rbs = settings_io_cb.rwbs;
 	off_t off;
@@ -284,7 +288,7 @@ int settings_line_entry_copy(void *dst_ctx, off_t dst_off, void *src_ctx,
 			     off_t src_off, size_t len)
 {
 	int rc = -EINVAL;
-	char buf[16];
+	char buf[CONFIG_SETTINGS_IO_BUF_SIZE];
 	size_t chunk_size;
 
 	while (len) {
@@ -336,7 +340,7 @@ static int settings_line_cmp(char const *val, size_t val_len,
 {
 	size_t len_read, exp_len;
 	size_t rem;
-	char buf[16];
+	char buf[CONFIG_SETTINGS_IO_BUF_SIZE];
 	int rc = -EINVAL;
 	off_t off = 0;
 


### PR DESCRIPTION
This PR provides the support for storing settings using FCB backend in the STM32H7 internal flash memory. This is required because:
- It is only possible to write in that flash memory by blocks of 32 bytes, but FCB and settings subsytems implementation do not currently support such block size. This PR enables the user to increase the maximum supported write-block size. 
- The FCB settings backend does not currently offer a way to indicate which flash area ID to use for storing settings. That can be an issue for dual-bank flash memory when bank swapping is used, since the address of the storage partition will not be same depending on whether or not the bank are swapped. This PR enables the user to specify at runtime the flash area ID the FCB backend should use.