### PR TITLE
i2s stm32: Fix audio crackles issue

### DIFF
--- a/drivers/i2s/i2s_ll_stm32.c
+++ b/drivers/i2s/i2s_ll_stm32.c
@@ -506,6 +506,8 @@ static void dma_rx_callback(const struct device *dma_dev, void *arg,
 		goto rx_disable;
 	}
 
+	memset(stream->mem_block, 0x00, stream->cfg.mem_slab->block_size);
+
 	ret = reload_dma(stream->dev_dma, stream->dma_channel,
 			&stream->dma_cfg,
 #ifdef CONFIG_SOC_SERIES_STM32H7X
@@ -786,6 +788,8 @@ static int rx_stream_start_dma(struct stream *stream, const struct device *dev, 
 		return ret;
 	}
 
+	memset(stream->mem_block, 0x00, stream->cfg.mem_slab->block_size);
+
 	if (stream->master) {
 		if (full_duplex) {
 			LL_I2S_SetTransferMode(cfg->i2s, LL_I2S_MODE_MASTER_FULL_DUPLEX);
@@ -834,7 +838,7 @@ static int tx_stream_start_dma(struct stream *stream, const struct device *dev, 
 		return -ENOMEM;
 	}
 	stream->last_mem_block_size = stream->cfg.block_size;
-	memset(stream->last_mem_block, 0, stream->last_mem_block_size);
+	memset(stream->last_mem_block, 0x00, stream->cfg.mem_slab->block_size);
 	stream->tx_underrun = false;
 #endif
 


### PR DESCRIPTION
This change fixes crackles in the audio streams transiting through the I2S via DMA transfer.

During the investigations, while trying to get the system running on zephyr-3.4, we came to this solution fixing this issue (though there were other issues on the integration).

Applying this solution on zephyr-3.2 was enough to make the crackles disappearing and get the expected audio quality.